### PR TITLE
Fix typo on translate tag

### DIFF
--- a/templates/corpus/search.html
+++ b/templates/corpus/search.html
@@ -6,7 +6,7 @@
 
 <h1>{% translate "Busca no Corpus" %}</h1>
 
-<p>{% translate Você precisa escolher um idioma na coluna esquerda e uma modalidade na coluna direita.%}</p>
+<p>{% translate "Você precisa escolher um idioma na coluna esquerda e uma modalidade na coluna direita." %}</p>
 
 <form action="{% url 'corpus:search' %}">
   {% csrf_token %}


### PR DESCRIPTION
Translate tag on the search page had a missing pair of double quotes enclosing the text to be translated.